### PR TITLE
Initial fuzzing support

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "librscrc-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.librscrc]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "crc32"
+path = "fuzz_targets/crc32.rs"
+test = false
+doc = false
+
+
+[[bin]]
+name = "custom_crc32"
+path = "fuzz_targets/custom_crc32.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/crc32.rs
+++ b/fuzz/fuzz_targets/crc32.rs
@@ -1,0 +1,18 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use librscrc::prelude::*;
+
+fuzz_target!(|data: &[u8]| {
+    let mut naive = Crc32::new_naive();
+    let mut lookup = Crc32::new_lookup();
+    let mut hardware = Crc32::new_hardware();
+    let mut simd = Crc32::new_simd();
+    naive.update(data);
+    lookup.update(data);
+    hardware.update(data);
+    simd.update(data);
+    let naive_result = naive.digest();
+    assert_eq!(naive_result, lookup.digest());
+    assert_eq!(naive_result, hardware.digest());
+    assert_eq!(naive_result, simd.digest());
+});

--- a/fuzz/fuzz_targets/custom_crc32.rs
+++ b/fuzz/fuzz_targets/custom_crc32.rs
@@ -1,0 +1,22 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use librscrc::prelude::*;
+use std::convert::TryInto;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() >= 4 {
+        let polynomial = u32::from_le_bytes(data[..4].try_into().unwrap());
+        let data = &data[4..];
+        let mut naive = CustomCrc32::new_naive(polynomial);
+        let mut lookup = CustomCrc32::new_lookup(polynomial);
+        // there is no hardware implementation for a custom polynomial
+        // let mut hardware = CustomCrc32::new_hardware(polynomial);
+        let mut simd = CustomCrc32::new_simd(polynomial.into());
+        naive.update(data);
+        lookup.update(data);
+        simd.update(data);
+        let naive_result = naive.digest();
+        assert_eq!(naive_result, lookup.digest());
+        assert_eq!(naive_result, simd.digest());
+    }
+});


### PR DESCRIPTION
Verify that the results of all implementations match using a fuzzer.

See the [Rust fuzz book](https://rust-fuzz.github.io/book/) for details.